### PR TITLE
[FIX] exclude TDAC directory from search path

### DIFF
--- a/FoamMon/FoamDataStructures.py
+++ b/FoamMon/FoamDataStructures.py
@@ -146,6 +146,7 @@ class Cases():
                     "uniform",
                     "processor",
                     "constant",
+                    "TDAC",
                     "lagrangian",
                     "postProcessing",
                     "dynamicCode",
@@ -290,7 +291,12 @@ class Case():
             if not os.path.exists(proc_dir):
                 return 0
             r, ds, _ = next(walk(proc_dir))
-            ds = [float(d) for d in ds if "constant" not in d]
+            rem = [ "constant",
+                    "TDAC"]
+            for k in range(len(rem)):
+                ds.remove(rem[k])
+
+            ds = [float(d) for d in ds]
             if ds:
                 return max(ds)
             else:

--- a/FoamMon/FoamDataStructures.py
+++ b/FoamMon/FoamDataStructures.py
@@ -291,10 +291,10 @@ class Case():
             if not os.path.exists(proc_dir):
                 return 0
             r, ds, _ = next(walk(proc_dir))
-            rem = [ "constant",
+            rems = [ "constant",
                     "TDAC"]
-            for k in range(len(rem)):
-                ds.remove(rem[k])
+            for rem in rems:
+                ds.remove(rem)
 
             ds = [float(d) for d in ds]
             if ds:


### PR DESCRIPTION
OpenFOAM now offers a TDAC functionality and a directory named
'TDAC' is written in each processor directory. foamMon previoulsy
failed to convert the string 'TDAC' to a float. Therefore besides
'constant', also 'TDAC' should be excluded. Tested with OF-5.x.